### PR TITLE
Add Self-hosted api option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,9 @@ RUN pip install -r requirements.txt && \
 # Copy the current code to the 
 COPY . .
 
+ENV GEMINI_API_KEY=''
+ENV OPENAI_API_KEY=''
+EXPOSE 8501
+
 # Run ResuLLMe with Streamlit
 CMD [ "streamlit", "run", "src/Main.py" ]

--- a/src/Main.py
+++ b/src/Main.py
@@ -13,7 +13,7 @@ import json
 def select_llm_model():
     model_type = st.selectbox(
         "Select the model you want to use:",
-        ["OpenAI", "Gemini"],
+        ["OpenAI", "Gemini", "Self-Hosted"],
         index=0
     )
     return model_type
@@ -32,7 +32,7 @@ def get_llm_model_and_api(model_type):
             ["gpt-3.5-turbo", "gpt-4-turbo", "gpt-4o"],
             index=0,
         )
-    else:
+    elif model_type == "Gemini":
         api_key = os.getenv("GEMINI_API_KEY")
         if not api_key:
             api_key = st.text_input(
@@ -40,6 +40,35 @@ def get_llm_model_and_api(model_type):
                 type="password",
             )
         api_model = "gemini-1.5-flash"
+    else:
+        if os.getenv("GEMINI_API_KEY"):
+            api_key = os.getenv("GEMINI_API_KEY")
+        elif os.getenv("OPENAI_API_KEY"):
+            api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            api_key = st.text_input(
+                "Enter the self-hosted API key: [(Most times you can just write random text)]",
+                    type="password",
+            )
+        # Use Ollama API as default
+        location = "http://127.0.0.1:11434/v1"
+        location = st.text_input(
+            "Enter the self-hosted API location (e.g. " + location + "):",
+            type="default"
+        )
+        model_list = []
+        try:
+            client = openai.OpenAI(base_url=location, api_key=api_key)
+            model_list = [model.id for model in client.models.list()]
+        except:
+            st.markdown(
+                "The current API key or location is incorrect. Please try again."
+            )
+        api_model = st.selectbox(
+            "Select a model to use for the LLMs:",
+            model_list,
+            index=0
+        )
     return api_key, api_model
 
 

--- a/src/pages/03_FAQ.py
+++ b/src/pages/03_FAQ.py
@@ -33,7 +33,7 @@ with st.expander("**I want to use my own custom format to render my résumé. Is
 with st.expander("**What is the LaTeX format?**"):
     st.markdown(
     """
-    LaTeX (LAH-tek) is a document preparation system that is used to render PDFs. ResuLLMe uses LaTeX to render a new AI-curated résumé in a format chosen by you!
+    LaTeX is a document preparation system that is used to render PDFs. ResuLLMe uses LaTeX to render a new AI-curated résumé in a format chosen by you!
     """
     )
 

--- a/src/pages/03_FAQ.py
+++ b/src/pages/03_FAQ.py
@@ -12,14 +12,14 @@ st.markdown(
 with st.expander("**Do I need an OpenAI/Gemini API Key to run ResuLLMe?**"):
     st.markdown(
     """
-    **Yes**, as we currently only support ChatGPT and Google  Gemini. You can obtain your key [openai](https://platform.openai.com/account/api-keys)/[Gemini](https://aistudio.google.com/ ).
+    **No**, Resullme is able to use any OpenAPI-compatible endpoint, such as [Ollama](https://github.com/ollama/ollama). If you intend on using ChatGPT or Google Gemini, an API key is required.  You can obtain your key [openai](https://platform.openai.com/account/api-keys)/[Gemini](https://aistudio.google.com/ ).
     """
     )
 
 with st.expander("**Can I store my OpenAI/Gemini API Key instead of manually re-entering it?**"):
     st.markdown(
     """
-    **Yes**, you can store your key in an environment variable `OPENAI_API_KEY` for openAI or `GEMINI_API_KEY` for Google Gemini, but if the environment variable `OPENAI_API_KEY`/`GEMINI_API_KEY` is not defined, ResuLLMe will prompt the user for a key.
+    **Yes**, you can store your key in an environment variable. Use `OPENAI_API_KEY` for openAI, and `GEMINI_API_KEY` for Google Gemini, and either for self-hosted. If the environment variable `OPENAI_API_KEY`/`GEMINI_API_KEY` is not defined, ResuLLMe will prompt the user for a key.
     """
     )
 
@@ -33,7 +33,7 @@ with st.expander("**I want to use my own custom format to render my résumé. Is
 with st.expander("**What is the LaTeX format?**"):
     st.markdown(
     """
-    LaTeX is a document preparation system that is used to render PDFs. ResuLLMe uses LaTeX to render a new AI-curated résumé in a format chosen by you!
+    LaTeX (LAH-tek) is a document preparation system that is used to render PDFs. ResuLLMe uses LaTeX to render a new AI-curated résumé in a format chosen by you!
     """
     )
 

--- a/src/pages/03_FAQ.py
+++ b/src/pages/03_FAQ.py
@@ -19,7 +19,7 @@ with st.expander("**Do I need an OpenAI/Gemini API Key to run ResuLLMe?**"):
 with st.expander("**Can I store my OpenAI/Gemini API Key instead of manually re-entering it?**"):
     st.markdown(
     """
-    **Yes**, you can store your key in an environment variable. Use `OPENAI_API_KEY` for openAI, and `GEMINI_API_KEY` for Google Gemini, and either for self-hosted. If the environment variable `OPENAI_API_KEY`/`GEMINI_API_KEY` is not defined, ResuLLMe will prompt the user for a key.
+    **Yes**, you can store your key in an environment variable. Use `OPENAI_API_KEY` for openAI, `GEMINI_API_KEY` for Google Gemini, and either for self-hosted. If the environment variable `OPENAI_API_KEY`/`GEMINI_API_KEY` is not defined, ResuLLMe will prompt the user for a key.
     """
     )
 


### PR DESCRIPTION
* Enables the user to enter a url and API key to a self-hosted or alternate OpenAPI-compatible server.
* Will use the `OPENAI_API_KEY` or `GEMINI_API_KEY` env vars if they are set
* Allows selecting a model
* update faq

Issues: #3 #26 